### PR TITLE
fix failure in gathering link node information

### DIFF
--- a/lib/NRFlowSet.js
+++ b/lib/NRFlowSet.js
@@ -50,9 +50,13 @@ class NRFlowSet {
                     this.nodes.set(config.id, new NRSubflowInstance(config));
                     subflowInstances.push(this.nodes.get(config.id));
                 } else {
-                    this.nodes.set(config.id, new NRNode(config));
-                    if (config.type === "link in" || config.type === "link out") {
-                        linkNodes.push(this.nodes.get(config.id));
+                    // config.{id,type} are removed in NRNode constructor
+                    let id = config.id;
+                    let type = config.type;
+                    let node = new NRNode(config)
+                    this.nodes.set(id, node);
+                    if (type === "link in" || type === "link out") {
+                        linkNodes.push(node);
                     }
                 }
             } else {


### PR DESCRIPTION
The `no-loop` rule of nrlint fails to detect a loop created by link nodes.
This is caused by missing wire information of link nodes.
This PR try to fix this problem.